### PR TITLE
修复引用爆炸问题

### DIFF
--- a/src/recv_handler.py
+++ b/src/recv_handler.py
@@ -232,7 +232,7 @@ class RecvHandler:
                     if not in_reply:
                         ret_seg = await self.handle_reply_message(sub_message)
                         if ret_seg:
-                            seg_message.append(ret_seg)
+                            seg_message += ret_seg
                         else:
                             logger.warning("reply处理失败")
                     else:

--- a/src/recv_handler.py
+++ b/src/recv_handler.py
@@ -405,6 +405,8 @@ class RecvHandler:
             logger.warning("获取被引用的消息详情失败")
             return None
         reply_message = await self.handle_real_message(message_detail, in_reply=True)
+        if reply_message == None:
+            reply_message = "(获取发言内容失败)"
         sender_info: dict = message_detail.get("sender")
         sender_nickname: str = sender_info.get("nickname")
         sender_id: str = sender_info.get("user_id")


### PR DESCRIPTION
![c6e60a65df989c4a879a7cc0f22a23b3](https://github.com/user-attachments/assets/be0cf1f3-c210-4baa-ae58-f7ace19ab4c1)

handle_reply_message 函数返回的是一个 list，所以使用 append 操作会导致后面后面无法处理这个列表，使用`+=`把返回的引用内容加入 seg_message 中即可。

#14 
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 将 `append` 替换为 `+=`，以在处理回复消息时正确扩展消息段列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace `append` with `+=` to correctly extend the message segments list when processing reply messages

</details>