### PR TITLE
修复戳一戳

### DIFF
--- a/src/recv_handler.py
+++ b/src/recv_handler.py
@@ -463,7 +463,7 @@ class RecvHandler:
 
         source_name: str = None
         source_cardname: str = None
-        if group_id:
+        if group_id != "None":
             member_info: dict = await get_member_info(self.server_connection, group_id, user_id)
             if member_info:
                 source_name = member_info.get("nickname")

--- a/src/recv_handler.py
+++ b/src/recv_handler.py
@@ -487,7 +487,7 @@ class RecvHandler:
         )
 
         group_info: GroupInfo = None
-        if group_id:
+        if group_id and group_id != "None":
             fetched_group_info = await get_group_info(self.server_connection, group_id)
             group_name: str = None
             if fetched_group_info:

--- a/src/recv_handler.py
+++ b/src/recv_handler.py
@@ -536,8 +536,8 @@ class RecvHandler:
         else:
             return None
         try:
-            first_txt = raw_info[2].get("text", "戳了戳")
-            second_txt = raw_info[4].get("text", "")
+            first_txt = raw_info[2].get("txt", "戳了戳")
+            second_txt = raw_info[4].get("txt", "")
         except Exception as e:
             logger.warning(f"解析戳一戳消息失败，使用默认文本：{str(e)}")
             first_txt = "戳了戳"

--- a/src/recv_handler.py
+++ b/src/recv_handler.py
@@ -463,7 +463,7 @@ class RecvHandler:
 
         source_name: str = None
         source_cardname: str = None
-        if group_id != "None":
+        if group_id and group_id != "None":
             member_info: dict = await get_member_info(self.server_connection, group_id, user_id)
             if member_info:
                 source_name = member_info.get("nickname")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/73706c10-90be-4406-8a08-1dd7a7fba983)
![image](https://github.com/user-attachments/assets/8c07afba-7671-4d7e-853d-ecc4e0c2f737)
修改为正确键名，获取戳一戳文本
修复判断，使私聊信息能发过去

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修正了用于从 'text' 中检索 poke 通知文本的键为 'txt'，以确保正确的消息解析

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the key used to retrieve poke notification text from 'text' to 'txt' to ensure proper message parsing

</details>