### PR TITLE
增加拒收戳一戳和自动戳回去功能

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -47,6 +47,9 @@ class Config:
             self.mai_port = raw_config["MaiBot_Server"].get("port", 8000)
             self.debug_level = raw_config["Debug"].get("level", "INFO")
             self.use_tts = raw_config["Voice"].get("use_tts", False)
+            self.notify_enable = raw_config["Notify"].get("enable", True)
+            self.notify_auto_group = raw_config["Notify"].get("auto_group", False)
+            self.notify_auto_friend = raw_config["Notify"].get("auto_friend", False)
         else:
             logger.error("配置文件不存在！")
             logger.info("正在创建配置文件...")

--- a/template/template_config.toml
+++ b/template/template_config.toml
@@ -16,6 +16,11 @@ group_list = []
 private_list = []
 enable_temp = false
 
+[Notify] # 戳一戳响应
+enable = true       # 是否将戳一戳转化为文本
+auto_group = false  # 群聊自动戳回去
+auto_friend = false # 私聊自动戳回去
+
 [Voice] # 发送语音设置
 use_tts = false # 是否使用tts语音（请确保你配置了tts并有对应的adapter）
 


### PR DESCRIPTION
需要增加config选项

另外类似功能到底是给MaiBot还是adapter？MaiBot是否应该学会使用不同Adapter的特色功能？我觉得需要好好考虑一下。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加可配置的戳一戳通知和自动回复功能

新功能：
- 支持在启用时将戳一戳事件转换为文本消息
- 允许根据配置设置在群聊和好友聊天中自动戳回去
- 通过 send_handler 向 MaiBot 适配器提供内部戳一戳通知

增强功能：
- 扩展配置模板和加载以包含通知选项（enable、auto_group、auto_friend）
- 调整通知处理日志消息以区分跳过的通知

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable poke notification and auto-response functionality

New Features:
- Support converting poke events into text messages when enabled
- Allow automatic poke-back in group and friend chats based on config settings
- Provide internal poke notifications via send_handler to the MaiBot adapter

Enhancements:
- Extend configuration template and loading to include Notify options (enable, auto_group, auto_friend)
- Adjust notice handling log message to distinguish skipped notices

</details>