### PR TITLE
添加了戳一戳的命令

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -72,6 +72,7 @@ class CommandType(Enum):
     GROUP_BAN = "set_group_ban"  # 禁言用户
     GROUP_WHOLE_BAN = "set_group_whole_ban"  # 群全体禁言
     GROUP_KICK = "set_group_kick"  # 踢出群聊
-
+    SEND_POKE = "send_poke" # 戳一戳
+    
     def __str__(self) -> str:
         return self.value

--- a/src/send_handler.py
+++ b/src/send_handler.py
@@ -97,6 +97,8 @@ class SendHandler:
                     command, args_dict = self.handle_whole_ban_command(seg_data.get("args"), group_info)
                 case CommandType.GROUP_KICK.name:
                     command, args_dict = self.handle_kick_command(seg_data.get("args"), group_info)
+                case CommandType.SEND_POKE.name:
+                    command, args_dict = self.handle_poke_command(seg_data.get("args"), group_info)
                 case _:
                     logger.error(f"未知命令: {command_name}")
                     return
@@ -292,6 +294,33 @@ class SendHandler:
                 "group_id": group_id,
                 "user_id": user_id,
                 "reject_add_request": False,  # 不拒绝加群请求
+            },
+        )
+    
+    def handle_poke_command(self, args: Dict[str, Any], group_info: GroupInfo) -> Tuple[str, Dict[str, Any]]:
+        """处理戳一戳命令
+
+        Args:
+            args (Dict[str, Any]): 参数字典
+            group_info (GroupInfo): 群聊信息（对应目标群聊）
+
+        Returns:
+            Tuple[CommandType, Dict[str, Any]]
+        """
+        user_id: int = int(args["qq_id"])
+        if group_info == None:
+            group_id = None
+        else:        
+            group_id: int = int(group_info.group_id)
+            if group_id <= 0:
+                raise ValueError("群组ID无效")
+        if user_id <= 0:
+            raise ValueError("用户ID无效")
+        return (
+            CommandType.SEND_POKE.value,
+            {
+                "group_id": group_id,
+                "user_id": user_id,
             },
         )
 


### PR DESCRIPTION
比较智能，送来的消息如果没有group_info（为NONE）直接识别为私聊戳一戳，有group_info及其内部的group_id就是群聊戳一戳。

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

新特性:
- 引入 'poke' (戳一戳) 命令支持

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce 'poke' (戳一戳) command support

</details>