### PR TITLE
添加对会员/活动特殊动图（创意玩法）戳一戳处理

### DIFF
--- a/src/recv_handler/notice_handler.py
+++ b/src/recv_handler/notice_handler.py
@@ -17,6 +17,7 @@ from src.utils import (
     get_member_info,
     get_self_info,
     get_stranger_info,
+    get_image_base64,
     read_ban_list,
 )
 

--- a/src/recv_handler/notice_handler.py
+++ b/src/recv_handler/notice_handler.py
@@ -225,7 +225,7 @@ class NoticeHandler:
         )
         
         seg_data: List[Seg] = []
-        acton_seg: Seg = Seg(type=RealMessageType.text, data="戳了戳")
+        acton_seg: Seg = Seg(type="text", data="戳了戳")
         action: str = "戳了戳"
         second_txt: str = ""    
         submit_notice_seg: Seg = None
@@ -245,14 +245,14 @@ class NoticeHandler:
                     acton_seg = Seg(type="emoji", data=image_base64)
                 except Exception as e:
                     logger.error(f"会员/活动戳一戳动图处理失败: {str(e)}")
-                    acton_seg = Seg(type=RealMessageType.text, data="戳了戳")
+                    acton_seg = Seg(type="text", data="戳了戳")
                 
                 second_txt = raw_info[3].get("txt", "")
                 suffix: str = f"{target_name}{second_txt}"
         
-                seg_data.append(Seg(type=RealMessageType.text, data=display_name))
+                seg_data.append(Seg(type="text", data=display_name))
                 seg_data.append(acton_seg)
-                seg_data.append(Seg(type=RealMessageType.text, data=suffix))
+                seg_data.append(Seg(type="text", data=suffix))
                 
                 submit_notice_seg = Seg(
                     type="seglist",


### PR DESCRIPTION
添加对创意玩法内只有表情动图而不带文字描述的会员与活动特殊戳一戳进行处理

已知问题：动图只能够识别第一帧（可以尝试通过动图URL解析成文字描述，但如果官方更新可能会失效（？），而且我不会python :( ）