### PR TITLE
新增了正则表达式过滤/放行

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "version": "1.0.1",
-  "name": "napcat_adapter_builtin",
+  "name": "Napcat_Adapter",
   "description": "Built-in NapCat adapter plugin for QQ / NapCat message gateway and platform actions.",
   "author": {
     "name": "MaiBot Team",

--- a/config.py
+++ b/config.py
@@ -356,6 +356,55 @@ class NapCatFilterConfig(PluginConfigBase):
             "order": 0,
         },
     )
+    regex_filter_enabled: bool = Field(
+        default=False,
+        description="是否启用正则表达式消息过滤。",
+        json_schema_extra={
+            "hint": "开启后将根据正则表达式规则过滤入站消息。",
+            "label": "启用正则过滤",
+            "order": 1,
+        },
+    )
+    regex_filter_mode: Literal["blacklist", "whitelist"] = Field(
+        default="blacklist",
+        description="正则过滤模式。blacklist 匹配则丢弃，whitelist 仅放行匹配的消息。",
+        json_schema_extra={
+            "hint": "黑名单模式下匹配正则的消息会被丢弃；白名单模式下仅匹配正则的消息会被放行。",
+            "label": "正则过滤模式",
+            "order": 2,
+        },
+    )
+    regex_filter_patterns: List[str] = Field(
+        default_factory=list,
+        description="正则表达式列表，支持 Python re 模块语法。",
+        json_schema_extra={
+            "hint": "每条规则为一个 Python 正则表达式，消息文本将逐条匹配。无效的正则表达式会在启动时记录警告并跳过。",
+            "label": "正则表达式列表",
+            "order": 3,
+            "placeholder": r"例如：^广告.*|spam",
+        },
+    )
+    regex_filter_show_dropped: bool = Field(
+        default=False,
+        description="是否显示未通过正则过滤而被丢弃的消息日志。",
+        json_schema_extra={
+            "hint": "关闭后不会记录因正则过滤而被丢弃的日志，默认关闭以减少刷屏。",
+            "label": "显示正则过滤丢弃日志",
+            "order": 4,
+        },
+    )
+
+    @field_validator("regex_filter_mode", mode="before")
+    @classmethod
+    def _normalize_regex_filter_mode(cls, value: Any) -> Literal["whitelist", "blacklist"]:
+        """规范化正则过滤模式字段。"""
+        return _normalize_list_mode(value)
+
+    @field_validator("regex_filter_patterns", mode="before")
+    @classmethod
+    def _normalize_regex_filter_patterns(cls, value: Any) -> List[str]:
+        """规范化正则表达式列表字段。"""
+        return _normalize_string_list(value)
 
 
 class NapCatPluginSettings(PluginConfigBase):

--- a/config.py
+++ b/config.py
@@ -539,7 +539,12 @@ class NapCatFilterConfig(PluginConfigBase):
     @classmethod
     def _normalize_regex_filter_mode(cls, value: Any) -> Literal["whitelist", "blacklist"]:
         """规范化正则过滤模式字段。"""
-        return _normalize_list_mode(value)
+        normalized_value = _normalize_string(value)
+        if normalized_value == "whitelist":
+            return "whitelist"
+        if normalized_value not in ("whitelist", "blacklist"):
+            LOGGER.warning(f"无效的 regex_filter_mode 值 '{value}'，已回退到 'blacklist'")
+        return "blacklist"
 
     @field_validator("regex_filter_patterns", mode="before")
     @classmethod

--- a/filters.py
+++ b/filters.py
@@ -1,8 +1,107 @@
 """NapCat 入站消息过滤。"""
 
-from typing import Any, Collection
+from __future__ import annotations
 
-from .config import NapCatChatConfig
+import re
+from typing import Any, Collection, List, Pattern
+
+from .config import NapCatChatConfig, NapCatFilterConfig
+
+
+class NapCatRegexFilter:
+    """NapCat 正则表达式消息内容过滤器。
+
+    通过配置的正则表达式列表对消息纯文本进行匹配，
+    支持黑名单（匹配则丢弃）和白名单（仅放行匹配）两种模式。
+    """
+
+    def __init__(self, logger: Any) -> None:
+        """初始化正则表达式过滤器。
+
+        Args:
+            logger: 插件日志对象。
+        """
+        self._logger = logger
+        self._compiled_patterns: List[Pattern[str]] = []
+        self._source_patterns: List[str] = []
+
+    def reload_patterns(self, patterns: List[str]) -> None:
+        """根据正则表达式列表重新编译。
+
+        无效的正则表达式会被记录警告并跳过。
+
+        Args:
+            patterns: 正则表达式字符串列表。
+        """
+        compiled: List[Pattern[str]] = []
+        source: List[str] = []
+        for pattern_text in patterns:
+            try:
+                compiled.append(re.compile(pattern_text))
+                source.append(pattern_text)
+            except re.error as exc:
+                self._logger.warning(f"NapCat 正则过滤器忽略无效正则表达式 '{pattern_text}': {exc}")
+        self._compiled_patterns = compiled
+        self._source_patterns = source
+        self._logger.debug(
+            f"NapCat 正则过滤器已加载 {len(compiled)} 条规则: {source}"
+        )
+
+    def is_message_allowed(self, plain_text: str, filter_config: NapCatFilterConfig) -> bool:
+        """检查消息文本是否通过正则表达式过滤。
+
+        Args:
+            plain_text: 消息纯文本内容。
+            filter_config: 当前生效的消息过滤配置。
+
+        Returns:
+            bool: 若消息允许继续进入 Host，则返回 ``True``。
+        """
+        if not filter_config.regex_filter_enabled:
+            return True
+
+        if not self._compiled_patterns:
+            return True
+
+        matched = self._matches_any_pattern(plain_text)
+
+        if filter_config.regex_filter_mode == "blacklist":
+            # 黑名单模式：匹配则丢弃
+            if matched:
+                self._log_regex_rejection(
+                    filter_config.regex_filter_show_dropped,
+                    f"NapCat 消息匹配黑名单正则，消息被丢弃: {plain_text!r}",
+                )
+                return False
+            return True
+
+        # 白名单模式：不匹配则丢弃
+        if not matched:
+            self._log_regex_rejection(
+                filter_config.regex_filter_show_dropped,
+                f"NapCat 消息未匹配白名单正则，消息被丢弃: {plain_text!r}",
+            )
+            return False
+        return True
+
+    def _matches_any_pattern(self, text: str) -> bool:
+        """判断文本是否匹配任意一条已编译的正则表达式。
+
+        Args:
+            text: 待匹配的文本。
+
+        Returns:
+            bool: 若匹配到任意一条正则，则返回 ``True``。
+        """
+        for pattern in self._compiled_patterns:
+            if pattern.search(text):
+                return True
+        return False
+
+    def _log_regex_rejection(self, enabled: bool, message: str) -> None:
+        """按配置决定是否记录正则过滤丢弃日志。"""
+        if enabled:
+            self._logger.warning(message)
 
 
 class NapCatChatFilter:

--- a/filters.py
+++ b/filters.py
@@ -61,6 +61,12 @@ class NapCatRegexFilter:
             return True
 
         if not self._compiled_patterns:
+            if filter_config.regex_filter_mode == "whitelist":
+                self._log_regex_rejection(
+                    filter_config.regex_filter_show_dropped,
+                    "NapCat 白名单正则过滤器无有效规则，消息被丢弃",
+                )
+                return False
             return True
 
         matched = self._matches_any_pattern(plain_text)

--- a/plugin.py
+++ b/plugin.py
@@ -206,6 +206,13 @@ class NapCatAdapterPlugin(
                 "NapCat 聊天名单过滤已关闭：将忽略 group_list 与 private_list，仅保留 ban_user_id 和官方机器人屏蔽规则"
             )
 
+        runtime_bundle.regex_filter.reload_patterns(settings.filters.regex_filter_patterns)
+        if settings.filters.regex_filter_enabled and settings.filters.regex_filter_patterns:
+            self.ctx.logger.info(
+                f"NapCat 正则消息过滤已启用: 模式={settings.filters.regex_filter_mode}，"
+                f"规则数={len(settings.filters.regex_filter_patterns)}"
+            )
+
         runtime_bundle.transport.configure(settings.napcat_server)
         await runtime_bundle.transport.start()
 

--- a/runtime/builder.py
+++ b/runtime/builder.py
@@ -7,7 +7,7 @@ from typing import Any, Awaitable, Callable, Coroutine
 from ..codecs.inbound import NapCatInboundCodec
 from ..codecs.notice import NapCatNoticeCodec
 from ..codecs.outbound import NapCatOutboundCodec
-from ..filters import NapCatChatFilter
+from ..filters import NapCatChatFilter, NapCatRegexFilter
 from ..heartbeat_monitor import NapCatHeartbeatMonitor
 from ..runtime_state import NapCatRuntimeStateManager
 from ..services import (
@@ -57,6 +57,7 @@ class NapCatRuntimeBuilder:
             NapCatRuntimeBundle: 已完成依赖注入的运行时组件集合。
         """
         chat_filter = NapCatChatFilter(self._logger)
+        regex_filter = NapCatRegexFilter(self._logger)
         transport = NapCatTransportClient(
             logger=self._logger,
             on_connection_opened=on_connection_opened,
@@ -97,6 +98,7 @@ class NapCatRuntimeBuilder:
             official_bot_guard=official_bot_guard,
             outbound_codec=outbound_codec,
             query_service=query_service,
+            regex_filter=regex_filter,
             runtime_state=runtime_state,
             transport=transport,
         )

--- a/runtime/bundle.py
+++ b/runtime/bundle.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from ..codecs.inbound import NapCatInboundCodec
 from ..codecs.notice import NapCatNoticeCodec
 from ..codecs.outbound import NapCatOutboundCodec
-from ..filters import NapCatChatFilter
+from ..filters import NapCatChatFilter, NapCatRegexFilter
 from ..heartbeat_monitor import NapCatHeartbeatMonitor
 from ..runtime_state import NapCatRuntimeStateManager
 from ..services import (
@@ -35,4 +35,5 @@ class NapCatRuntimeBundle:
     outbound_codec: NapCatOutboundCodec
     query_service: NapCatQueryService
     runtime_state: NapCatRuntimeStateManager
+    regex_filter: NapCatRegexFilter
     transport: NapCatTransportClient

--- a/runtime/router.py
+++ b/runtime/router.py
@@ -121,6 +121,10 @@ class NapCatEventRouter:
             self._logger.warning(f"NapCat 入站消息格式不受支持，已丢弃: {exc}")
             return
 
+        plain_text = str(message_dict.get("processed_plain_text") or "").strip()
+        if not runtime.regex_filter.is_message_allowed(plain_text, settings.filters):
+            return
+
         route_metadata = self._build_route_metadata(self_id, settings.napcat_server.connection_id)
         external_message_id = str(payload.get("message_id") or "").strip()
         accepted = await self._gateway_capability.route_message(


### PR DESCRIPTION
功能描述
在 NapCat 适配器的入站消息处理管道中新增正则表达式内容过滤功能，支持对消息纯文本进行正则匹配，可配置黑名单/白名单两种过滤模式。

修改文件清单
1. config.py — 新增配置字段
在 NapCatFilterConfig 中新增 4 个扁平化配置字段：
regex_filter_enabled: bool — 是否启用正则过滤（默认关闭）
regex_filter_mode: Literal["blacklist", "whitelist"] — 过滤模式
regex_filter_patterns: List[str] — 正则表达式列表
regex_filter_show_dropped: bool — 是否显示丢弃日志

2. filters.py — 新增 NapCatRegexFilter 类
reload_patterns(patterns) — 编译正则表达式列表，无效正则记录警告并跳过
is_message_allowed(plain_text, filter_config) — 对消息文本执行正则匹配过滤
支持黑名单模式（匹配则丢弃）和白名单模式（仅放行匹配的消息）

3. runtime/bundle.py — 注册新组件
NapCatRuntimeBundle 数据类中新增 regex_filter: NapCatRegexFilter 字段

4. runtime/builder.py — 初始化新组件
NapCatRuntimeBuilder.build() 中创建 NapCatRegexFilter 实例并注入 Bundle

5. runtime/router.py — 集成过滤逻辑
在 handle_inbound_message() 中，消息解码后、注入 Host 前，调用 regex_filter.is_message_allowed() 执行正则过滤

6. plugin.py — 配置加载与重载
_restart_connection_if_needed() 中调用 regex_filter.reload_patterns() 编译正则
配置热重载时自动重新编译
消息过滤流程

入站消息 → 忽略自身消息 → 聊天名单过滤 → 官方机器人过滤 → 消息解码 → 【正则内容过滤】 → 注入 Host
示例图
<img width="797" height="728" alt="233adcfe77668fa90b28a46141c8dce4" src="https://github.com/user-attachments/assets/f77af535-176d-469d-9ad7-43037243c635" />
