### PR TITLE
fix: notice 事件补聊天黑白名单过滤，避免黑白名单外的群/私聊触发戳一戳反应等类似的 notice 事件

### DIFF
--- a/runtime/router.py
+++ b/runtime/router.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Mapping, Optional, Protocol
 
 import asyncio
 
+from ..codecs.notice.helpers import resolve_actor_user_id
 from ..config import NapCatPluginSettings
 from ..types import NapCatPayloadDict
 from .bundle import NapCatRuntimeBundle
@@ -161,12 +162,25 @@ class NapCatEventRouter:
     ) -> None:
         """将单条通知载荷转换并注入 Host。
 
+        注入前按与普通消息一致的口径执行聊天名单过滤，
+        避免非名单内群聊/私聊的通知事件（如戳一戳）泄漏进 Host。
+
         Args:
             payload: NapCat 通知载荷。
             self_id: 当前机器人账号 ID。
             connection_id: 当前连接标识。
         """
         runtime = self._require_runtime()
+        settings = self._load_settings()
+
+        group_id = str(payload.get("group_id") or "").strip()
+        actor_user_id = resolve_actor_user_id(payload)
+        # 群/私聊至少能确定其一时才做名单过滤；两者皆空的通知无法归类，保持放行
+        if (group_id or actor_user_id) and not runtime.chat_filter.is_inbound_chat_allowed(
+            actor_user_id, group_id, settings.chat
+        ):
+            return
+
         message_dict = await runtime.notice_codec.build_notice_message_dict(payload)
         if message_dict is None:
             return


### PR DESCRIPTION
# fix(router): notice 事件注入 Host 前执行聊天名单过滤

## 问题

启用聊天名单过滤（`chat.enable_chat_list_filter`，白名单模式）后，bot 仍会在名单外的群聊/私聊中响应戳一戳。

## 根因

`runtime/router.py` 中两条入站路径待遇不一致：

- 普通消息：`handle_inbound_message` 注入 Host 前会调用
  `chat_filter.is_inbound_chat_allowed(...)` 做群聊/私聊名单过滤；
- notice 事件：`handle_notice_event` → `route_notice_payload` 直接转换并注入
  Host，**没有任何名单过滤**。

戳一戳是 `notify.poke` 类型的 notice，因此名单外聊天的戳一戳事件照样进入
Host，Host 自带的戳一戳回应和订阅 notice 的插件都会被触发。同理，名单外聊天
的撤回、禁言、入群等通知也会泄漏进 Host。

## 修复

在 `route_notice_payload` 注入 Host 前，复用 `is_inbound_chat_allowed` 按与
普通消息一致的口径过滤：

- 群通知按 `group_id` 走群名单，私聊通知（无 `group_id`，如好友戳一戳）按事
  件主体走私聊名单；
- 事件主体用 `codecs/notice/helpers.resolve_actor_user_id` 解析，与 notice
  编解码器构造 `user_info` 的口径一致（`operator_id` 优先、`"0"` 哨兵归一、
  自然解禁合成通知返回空串），`ban_user_id` 全局屏蔽因此对通知同样生效；
- `group_id` 与事件主体皆为空的通知无法归类到任何聊天，保持放行（兜底，实践
  中 friend 类 notice 都带 `user_id`）。

## 兼容性

- 未启用名单过滤（`enable_chat_list_filter = false`）时行为完全不变（仅
  `ban_user_id` 全局屏蔽开始对通知生效，与普通消息口径对齐）。
- 已确认的无害副作用：bot 在私聊主动戳人后 NapCat 回灌的回声 notice
  （`user_id` = bot 自身）在私聊白名单模式下会被过滤；该回声本就不应产生任
  何响应，无功能影响。