### PR TITLE
feat: 新增逐类型通知事件开关，默认过滤 input_status 等噪音通知

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "name": "Napcat_Adapter 适配器",
   "description": "插件版Napcat适配器，提供与Napcat的连接功能。",
   "author": {

--- a/config.py
+++ b/config.py
@@ -50,6 +50,28 @@ def _schema_i18n(
     return i18n
 
 
+def _notice_field(
+    *,
+    label: str,
+    description: str,
+    order: int,
+    label_en: str,
+    label_ja: str,
+) -> Any:
+    """构造通知事件开关字段，统一默认放行与 WebUI 多语言标签。"""
+
+    return Field(
+        default=True,
+        description=description,
+        json_schema_extra={
+            "hint": description,
+            "i18n": _schema_i18n(label_en=label_en, label_ja=label_ja),
+            "label": label,
+            "order": order,
+        },
+    )
+
+
 class NapCatPluginOptions(PluginConfigBase):
     """插件级配置。"""
 
@@ -480,7 +502,7 @@ class NapCatFilterConfig(PluginConfigBase):
     """消息过滤配置。"""
 
     __ui_label__: ClassVar[str] = "消息过滤"
-    __ui_order__: ClassVar[int] = 3
+    __ui_order__: ClassVar[int] = 4
 
     ignore_self_message: bool = Field(
         default=True,
@@ -553,12 +575,117 @@ class NapCatFilterConfig(PluginConfigBase):
         return _normalize_string_list(value)
 
 
+class NapCatNoticeConfig(PluginConfigBase):
+    """通知事件传递配置。
+
+    采用白名单式开关：仅明确启用的通知类型会注入 Host，
+    未在此处列出的通知类型（如输入状态 notify.input_status）默认丢弃。
+    """
+
+    __ui_label__: ClassVar[str] = "通知事件"
+    __ui_order__: ClassVar[int] = 3
+
+    enabled: bool = Field(
+        default=True,
+        description="是否将 NapCat 推送的通知事件转发给 Host。",
+        json_schema_extra={
+            "hint": "关闭后，戳一戳、禁言、撤回、入群退群等所有通知事件都不会传入 Host。",
+            "i18n": _schema_i18n(
+                label_en="Enable notice events",
+                label_ja="通知イベントを有効化",
+                hint_en="When disabled, poke, ban, recall, member change and all other notice events are not routed to the Host.",
+                hint_ja="無効にすると、poke、禁言、撤回、メンバー変更などすべての通知イベントは Host に転送されません。",
+            ),
+            "label": "启用通知事件",
+            "order": 0,
+        },
+    )
+    enable_poke: bool = _notice_field(
+        label="传递戳一戳",
+        description="是否传递戳一戳通知。",
+        order=1,
+        label_en="Route poke",
+        label_ja="poke を転送",
+    )
+    enable_friend_recall: bool = _notice_field(
+        label="传递好友撤回",
+        description="是否传递好友消息撤回通知。",
+        order=2,
+        label_en="Route friend recall",
+        label_ja="友達の撤回を転送",
+    )
+    enable_group_recall: bool = _notice_field(
+        label="传递群消息撤回",
+        description="是否传递群消息撤回通知。",
+        order=3,
+        label_en="Route group recall",
+        label_ja="グループ撤回を転送",
+    )
+    enable_group_ban: bool = _notice_field(
+        label="传递禁言",
+        description="是否传递群禁言和解除禁言通知。",
+        order=4,
+        label_en="Route group ban",
+        label_ja="グループ禁言を転送",
+    )
+    enable_group_msg_emoji_like: bool = _notice_field(
+        label="传递消息表情回应",
+        description="是否传递群消息表情回应通知。",
+        order=5,
+        label_en="Route emoji reactions",
+        label_ja="絵文字リアクションを転送",
+    )
+    enable_group_upload: bool = _notice_field(
+        label="传递群文件上传",
+        description="是否传递群文件上传通知。",
+        order=6,
+        label_en="Route group uploads",
+        label_ja="グループファイルを転送",
+    )
+    enable_group_increase: bool = _notice_field(
+        label="传递入群",
+        description="是否传递群成员增加通知。",
+        order=7,
+        label_en="Route member joins",
+        label_ja="参加通知を転送",
+    )
+    enable_group_decrease: bool = _notice_field(
+        label="传递退群",
+        description="是否传递群成员减少通知。",
+        order=8,
+        label_en="Route member leaves",
+        label_ja="退出通知を転送",
+    )
+    enable_group_admin: bool = _notice_field(
+        label="传递管理员变动",
+        description="是否传递群管理员变动通知。",
+        order=9,
+        label_en="Route admin changes",
+        label_ja="管理者変更を転送",
+    )
+    enable_essence: bool = _notice_field(
+        label="传递精华消息",
+        description="是否传递精华消息变动通知。",
+        order=10,
+        label_en="Route essence changes",
+        label_ja="精華メッセージを転送",
+    )
+    enable_group_name: bool = _notice_field(
+        label="传递群名变更",
+        description="是否传递群名称变更通知。",
+        order=11,
+        label_en="Route group name changes",
+        label_ja="グループ名変更を転送",
+    )
+
+
 class NapCatPluginSettings(PluginConfigBase):
     """NapCat 插件完整配置。"""
 
     plugin: NapCatPluginOptions = Field(default_factory=NapCatPluginOptions)
     napcat_server: NapCatServerConfig = Field(default_factory=NapCatServerConfig)
     chat: NapCatChatConfig = Field(default_factory=NapCatChatConfig)
+    notice: NapCatNoticeConfig = Field(default_factory=NapCatNoticeConfig)
     filters: NapCatFilterConfig = Field(default_factory=NapCatFilterConfig)
 
     @model_validator(mode="before")
@@ -579,6 +706,7 @@ class NapCatPluginSettings(PluginConfigBase):
         legacy_connection_section = _as_mapping(raw_mapping.get("connection"))
         chat_section = _as_mapping(raw_mapping.get("chat"))
         filters_section = _as_mapping(raw_mapping.get("filters"))
+        notice_section = _as_mapping(raw_mapping.get("notice"))
 
         if legacy_connection_section:
             LOGGER.warning("NapCat 适配器检测到旧版 [connection] 配置段，已自动迁移到 [napcat_server]")
@@ -618,6 +746,7 @@ class NapCatPluginSettings(PluginConfigBase):
         return {
             "chat": chat_section,
             "filters": filters_section,
+            "notice": notice_section,
             "napcat_server": normalized_server_section,
             "plugin": plugin_section,
         }

--- a/filters.py
+++ b/filters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any, Collection, List, Pattern
 
-from .config import NapCatChatConfig, NapCatFilterConfig
+from .config import NapCatChatConfig, NapCatFilterConfig, NapCatNoticeConfig
 
 
 class NapCatRegexFilter:
@@ -185,3 +185,64 @@ class NapCatChatFilter:
         if list_type == "whitelist":
             return target_id in configured_ids
         return target_id not in configured_ids
+
+
+class NapCatNoticeFilter:
+    """NapCat 通知事件类型过滤器。
+
+    依据通知事件配置，按白名单方式决定某类通知是否允许注入 Host：
+    仅明确启用的类型放行，未列出的类型（如输入状态 ``notify.input_status``）默认丢弃。
+    """
+
+    _NOTICE_TYPE_FIELDS = {
+        "friend_recall": "enable_friend_recall",
+        "group_recall": "enable_group_recall",
+        "group_ban": "enable_group_ban",
+        "group_msg_emoji_like": "enable_group_msg_emoji_like",
+        "group_upload": "enable_group_upload",
+        "group_increase": "enable_group_increase",
+        "group_decrease": "enable_group_decrease",
+        "group_admin": "enable_group_admin",
+        "essence": "enable_essence",
+    }
+
+    def __init__(self, logger: Any) -> None:
+        """初始化通知事件过滤器。
+
+        Args:
+            logger: 插件日志对象。
+        """
+        self._logger = logger
+
+    def is_notice_event_allowed(
+        self,
+        notice_type: str,
+        sub_type: str,
+        notice_config: NapCatNoticeConfig,
+    ) -> bool:
+        """判断指定通知事件是否允许注入 Host。
+
+        Args:
+            notice_type: 通知事件主类型。
+            sub_type: 通知事件子类型；无子类型时为空字符串。
+            notice_config: 当前生效的通知事件配置。
+
+        Returns:
+            bool: 若该通知允许继续进入 Host，则返回 ``True``。
+        """
+        if not notice_config.enabled:
+            return False
+
+        if notice_type == "notify":
+            if sub_type == "poke":
+                return notice_config.enable_poke
+            if sub_type == "group_name":
+                return notice_config.enable_group_name
+            # notify 下的其它子类型（如输入状态 input_status）默认不传递
+            return False
+
+        field_name = self._NOTICE_TYPE_FIELDS.get(notice_type)
+        if field_name is None:
+            # 未在配置中列出的通知类型默认不传递
+            return False
+        return bool(getattr(notice_config, field_name))

--- a/plugin.py
+++ b/plugin.py
@@ -212,6 +212,8 @@ class NapCatAdapterPlugin(
                 f"NapCat 正则消息过滤已启用: 模式={settings.filters.regex_filter_mode}，"
                 f"规则数={len(settings.filters.regex_filter_patterns)}"
             )
+        if not settings.notice.enabled:
+            self.ctx.logger.info("NapCat 通知事件转发已整体关闭：所有通知都不会传入 Host")
 
         runtime_bundle.transport.configure(settings.napcat_server)
         await runtime_bundle.transport.start()

--- a/runtime/builder.py
+++ b/runtime/builder.py
@@ -7,7 +7,7 @@ from typing import Any, Awaitable, Callable, Coroutine
 from ..codecs.inbound import NapCatInboundCodec
 from ..codecs.notice import NapCatNoticeCodec
 from ..codecs.outbound import NapCatOutboundCodec
-from ..filters import NapCatChatFilter, NapCatRegexFilter
+from ..filters import NapCatChatFilter, NapCatNoticeFilter, NapCatRegexFilter
 from ..heartbeat_monitor import NapCatHeartbeatMonitor
 from ..runtime_state import NapCatRuntimeStateManager
 from ..services import (
@@ -57,6 +57,7 @@ class NapCatRuntimeBuilder:
             NapCatRuntimeBundle: 已完成依赖注入的运行时组件集合。
         """
         chat_filter = NapCatChatFilter(self._logger)
+        notice_filter = NapCatNoticeFilter(self._logger)
         regex_filter = NapCatRegexFilter(self._logger)
         transport = NapCatTransportClient(
             logger=self._logger,
@@ -95,6 +96,7 @@ class NapCatRuntimeBuilder:
             heartbeat_monitor=heartbeat_monitor,
             inbound_codec=inbound_codec,
             notice_codec=notice_codec,
+            notice_filter=notice_filter,
             official_bot_guard=official_bot_guard,
             outbound_codec=outbound_codec,
             query_service=query_service,

--- a/runtime/bundle.py
+++ b/runtime/bundle.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from ..codecs.inbound import NapCatInboundCodec
 from ..codecs.notice import NapCatNoticeCodec
 from ..codecs.outbound import NapCatOutboundCodec
-from ..filters import NapCatChatFilter, NapCatRegexFilter
+from ..filters import NapCatChatFilter, NapCatNoticeFilter, NapCatRegexFilter
 from ..heartbeat_monitor import NapCatHeartbeatMonitor
 from ..runtime_state import NapCatRuntimeStateManager
 from ..services import (
@@ -31,6 +31,7 @@ class NapCatRuntimeBundle:
     heartbeat_monitor: NapCatHeartbeatMonitor
     inbound_codec: NapCatInboundCodec
     notice_codec: NapCatNoticeCodec
+    notice_filter: NapCatNoticeFilter
     official_bot_guard: NapCatOfficialBotGuard
     outbound_codec: NapCatOutboundCodec
     query_service: NapCatQueryService

--- a/runtime/router.py
+++ b/runtime/router.py
@@ -173,6 +173,14 @@ class NapCatEventRouter:
         runtime = self._require_runtime()
         settings = self._load_settings()
 
+        notice_type = str(payload.get("notice_type") or "").strip()
+        sub_type = str(payload.get("sub_type") or "").strip()
+        if not runtime.notice_filter.is_notice_event_allowed(notice_type, sub_type, settings.notice):
+            self._logger.debug(
+                f"NapCat 通知事件未启用，已丢弃: {notice_type}.{sub_type or '<空>'}"
+            )
+            return
+
         group_id = str(payload.get("group_id") or "").strip()
         actor_user_id = resolve_actor_user_id(payload)
         # 群/私聊至少能确定其一时才做名单过滤；两者皆空的通知无法归类，保持放行


### PR DESCRIPTION
## 问题

私聊场景下，NapCat 会高频推送「对方正在输入」状态通知（`notice_type=notify`, `sub_type=input_status`）。适配器现有逻辑对未识别的 notice 走兜底渲染（`[notice] notify.input_status`）并注入 Host，导致主程序日志被这类无意义的状态通知刷屏，还会增大 token 消耗：

[所见] [私聊]xxx:[notice] notify.input_status

而 notice 通道此前只有聊天名单过滤（按 user/group），缺少按「通知类型」过滤的能力，无法单独屏蔽某一类通知。

## 改动

新增可配置的**逐类型通知事件开关**（`[notice]` 配置段），采用白名单式过滤：

- **`config.py`** 新增 `NapCatNoticeConfig`：总开关 `enabled` + 11 个分类开关
  （戳一戳 / 好友撤回 / 群撤回 / 禁言 / 表情回应 / 群文件 / 入群 / 退群 /
  管理员变动 / 精华 / 群名变更），默认全部开启，带中 / 英 / 日 WebUI 多语言标签；
  接入 `NapCatPluginSettings.notice` 与旧配置迁移。
- **`filters.py`** 新增 `NapCatNoticeFilter`：按 `notice_type` / `sub_type` 判断。
  `notify` 类只放行 `poke` / `group_name`，其余子类型（含 `input_status`）默认丢弃；未列入开关表的通知类型默认丢弃。
- **`runtime/router.py`** `route_notice_payload` 在注入 Host 前执行该过滤。
- **`runtime/builder.py` / `runtime/bundle.py`** 装配 `notice_filter` 组件。
- **`plugin.py`** 通知总开关关闭时输出提示日志。

## 行为变更

- 默认配置下，11 个开关覆盖渲染器现有的全部已知通知类型，**常规通知（戳一戳 / 撤回 / 禁言 / 入退群等）行为不变**。
- `notify.input_status` 等噪音通知，以及未列入开关表的冷门扩展通知，**默认不再注入 Host**；如需放行，在「通知事件」配置区打开对应开关即可。
- 通知类型过滤在 `ban_tracker.record_notice` 之后执行，**不影响禁言状态追踪**。