### PR TITLE
feat: 新增Websocket client/server模式选择，支持反向 WebSocket 连接

### DIFF
--- a/config.py
+++ b/config.py
@@ -131,92 +131,125 @@ class NapCatPluginOptions(PluginConfigBase):
 
 
 class NapCatServerConfig(PluginConfigBase):
-    """NapCat 正向 WebSocket 连接配置。"""
+    """NapCat WebSocket 连接配置。"""
 
     __ui_label__: ClassVar[str] = "NapCat 连接"
     __ui_order__: ClassVar[int] = 1
 
+    transport_mode: Literal["client", "server"] = Field(
+        default="client",
+        description="NapCat WebSocket 连接模式：client 为主动连接，server 为被动监听。",
+        json_schema_extra={
+            "hint": "client 模式由适配器主动连接 NapCat；server 模式由适配器监听端口，等待 NapCat 反向连接。",
+            "i18n": _schema_i18n(
+                label_en="Transport mode",
+                label_ja="接続モード",
+                hint_en="client: adapter actively connects to NapCat; server: adapter listens and waits for NapCat to connect.",
+                hint_ja="client: アダプターが NapCat へ接続します。server: アダプターが待受し、NapCat からの接続を待ちます。",
+            ),
+            "label": "连接模式",
+            "order": 0,
+        },
+    )
     host: str = Field(
         default=DEFAULT_NAPCAT_HOST,
-        description="NapCat WebSocket 服务主机地址。",
+        description="WebSocket 主机地址。",
         json_schema_extra={
-            "hint": "通常为运行 NapCat 的宿主机地址，默认使用本机回环地址。",
+            "hint": "client 模式下填写 NapCat 地址；server 模式下填写本适配器监听地址，默认本机回环地址。",
             "i18n": _schema_i18n(
                 label_en="Host address",
                 label_ja="ホストアドレス",
-                hint_en="Usually the host running NapCat. Defaults to the local loopback address.",
-                hint_ja="通常は NapCat を実行しているホストです。既定ではローカルのループバックアドレスを使用します。",
+                hint_en="In client mode this is NapCat host; in server mode this is the adapter bind host. Defaults to loopback.",
+                hint_ja="client モードでは NapCat のホスト、server モードではアダプターの待受ホストです。既定はループバックです。",
                 placeholder_en="127.0.0.1",
                 placeholder_ja="127.0.0.1",
             ),
             "label": "主机地址",
-            "order": 0,
+            "order": 1,
             "placeholder": "127.0.0.1",
         },
     )
     port: int = Field(
         default=DEFAULT_NAPCAT_PORT,
-        description="NapCat WebSocket 服务端口。",
+        description="WebSocket 端口。",
         json_schema_extra={
-            "hint": "与 NapCat 正向 WebSocket 服务监听端口保持一致。",
+            "hint": "client 模式下填写 NapCat 端口；server 模式下填写本适配器监听端口。",
             "i18n": _schema_i18n(
                 label_en="Port",
                 label_ja="ポート",
-                hint_en="Keep this consistent with the NapCat forward WebSocket listening port.",
-                hint_ja="NapCat の正方向 WebSocket 待受ポートと一致させてください。",
+                hint_en="In client mode use NapCat listening port; in server mode use adapter listening port.",
+                hint_ja="client モードでは NapCat の待受ポート、server モードではアダプターの待受ポートです。",
             ),
             "label": "端口",
-            "order": 1,
+            "order": 2,
+        },
+    )
+    ws_path: str = Field(
+        default="/",
+        description="WebSocket 路径，默认根路径。",
+        json_schema_extra={
+            "hint": "client 模式会连接该路径；server 模式仅在该路径接受 WebSocket 升级。",
+            "i18n": _schema_i18n(
+                label_en="WebSocket path",
+                label_ja="WebSocket パス",
+                hint_en="Client mode connects to this path; server mode only accepts upgrades on this path.",
+                hint_ja="client モードではこのパスへ接続し、server モードではこのパスでのみアップグレードを受け付けます。",
+                placeholder_en="/ws",
+                placeholder_ja="/ws",
+            ),
+            "label": "WebSocket 路径",
+            "order": 3,
+            "placeholder": "/ws",
         },
     )
     token: str = Field(
         default="",
-        description="NapCat 访问令牌，未启用鉴权时可留空。",
+        description="WebSocket 鉴权令牌；未启用鉴权时可留空。",
         json_schema_extra={
-            "hint": "若 NapCat 开启了访问令牌校验，请在这里填写相同的 token。",
+            "hint": "client 模式下用于请求头 Authorization: Bearer <token>；server 模式下用于校验 NapCat 连接请求头中的 Bearer token。",
             "i18n": _schema_i18n(
                 label_en="Access token",
                 label_ja="アクセストークン",
-                hint_en="If NapCat access token verification is enabled, enter the same token here.",
-                hint_ja="NapCat でアクセストークン検証を有効にしている場合は、同じ token をここに入力してください。",
+                hint_en="Client mode sends Authorization: Bearer <token>; server mode validates the Bearer token in incoming requests.",
+                hint_ja="client モードでは Authorization: Bearer <token> を送信し、server モードでは受信リクエストの Bearer token を検証します。",
                 placeholder_en="Optional",
                 placeholder_ja="空欄可",
             ),
             "input_type": "password",
             "label": "访问令牌",
-            "order": 2,
+            "order": 4,
             "placeholder": "可留空",
         },
     )
     heartbeat_interval: float = Field(
         default=DEFAULT_HEARTBEAT_INTERVAL_SEC,
-        description="心跳超时判定间隔，单位为秒。",
+        description="WebSocket 心跳间隔，单位为秒。",
         json_schema_extra={
-            "hint": "用于判断 NapCat 连接是否失活，必须大于 0。",
+            "hint": "client/server 两种模式都会应用该值，用于维持连接活性并尽早发现失活连接。",
             "i18n": _schema_i18n(
                 label_en="Heartbeat interval (sec)",
                 label_ja="ハートビート間隔（秒）",
-                hint_en="Used to detect whether the NapCat connection is stale. Must be greater than 0.",
-                hint_ja="NapCat 接続が失活していないかを判定する間隔です。0 より大きい値にしてください。",
+                hint_en="Applied in both client and server modes to keep the connection alive and detect stale links. Must be greater than 0.",
+                hint_ja="client/server 両モードで適用され、接続維持と失活検知に使用されます。0 より大きい値にしてください。",
             ),
             "label": "心跳间隔（秒）",
-            "order": 3,
+            "order": 5,
             "step": 1,
         },
     )
     reconnect_delay_sec: float = Field(
         default=DEFAULT_RECONNECT_DELAY_SEC,
-        description="连接断开后的重连等待时间，单位为秒。",
+        description="client 模式下连接断开后的重连等待时间，单位为秒。",
         json_schema_extra={
-            "hint": "连接断开后会等待该时长再尝试重新连接。",
+            "hint": "仅对 client 模式生效；server 模式下该值不参与监听循环。",
             "i18n": _schema_i18n(
                 label_en="Reconnect delay (sec)",
                 label_ja="再接続待機（秒）",
-                hint_en="After a disconnect, wait this long before trying to reconnect.",
-                hint_ja="接続が切断された後、再接続を試すまでこの時間待機します。",
+                hint_en="Only effective in client mode: wait this long before reconnecting after a disconnect.",
+                hint_ja="client モードでのみ有効です。切断後、この時間待機してから再接続を試みます。",
             ),
             "label": "重连等待（秒）",
-            "order": 4,
+            "order": 6,
             "step": 1,
         },
     )
@@ -224,15 +257,15 @@ class NapCatServerConfig(PluginConfigBase):
         default=DEFAULT_ACTION_TIMEOUT_SEC,
         description="调用 NapCat 动作接口的超时时间，单位为秒。",
         json_schema_extra={
-            "hint": "发送消息、查询信息等动作会在超时后报错。",
+            "hint": "client/server 两种模式都会生效；发送消息、查询信息等动作会在超时后报错。",
             "i18n": _schema_i18n(
                 label_en="Action timeout (sec)",
                 label_ja="アクションタイムアウト（秒）",
-                hint_en="Actions such as sending messages or querying info fail after this timeout.",
-                hint_ja="メッセージ送信や情報取得などのアクションは、この時間を超えるとエラーになります。",
+                hint_en="Effective in both client and server modes. Actions such as sending messages or querying info fail after this timeout.",
+                hint_ja="client/server 両モードで有効です。メッセージ送信や情報取得などのアクションは、この時間を超えるとエラーになります。",
             ),
             "label": "动作超时（秒）",
-            "order": 5,
+            "order": 7,
             "step": 1,
         },
     )
@@ -250,19 +283,23 @@ class NapCatServerConfig(PluginConfigBase):
                 placeholder_ja="例：primary",
             ),
             "label": "连接标识",
-            "order": 6,
+            "order": 8,
             "placeholder": "例如：primary",
         },
     )
 
     def build_ws_url(self) -> str:
-        """构造正向 WebSocket 地址。
+        """构造 client 模式使用的 WebSocket 地址。
 
         Returns:
-            str: 供适配器作为客户端连接的 NapCat WebSocket 地址。
+            str: 供适配器主动连接 NapCat 使用的 WebSocket 地址。
         """
 
-        return f"ws://{self.host}:{self.port}"
+        return f"ws://{self.host}:{self.port}{self.ws_path}"
+
+    def is_server_mode(self) -> bool:
+        """判断当前传输层是否处于 server 模式。"""
+        return self.transport_mode == "server"
 
     @field_validator("host", mode="before")
     @classmethod
@@ -306,6 +343,32 @@ class NapCatServerConfig(PluginConfigBase):
         """
 
         return _normalize_string(value)
+
+    @field_validator("ws_path", mode="before")
+    @classmethod
+    def _normalize_ws_path(cls, value: Any) -> str:
+        """规范化 WebSocket 路径字段。"""
+        normalized_value = _normalize_string(value)
+        if not normalized_value:
+            return "/"
+
+        path = normalized_value.split("?", 1)[0].split("#", 1)[0].strip()
+        if not path:
+            return "/"
+        if not path.startswith("/"):
+            path = f"/{path}"
+
+        while "//" in path:
+            path = path.replace("//", "/")
+
+        return path or "/"
+
+    @field_validator("transport_mode", mode="before")
+    @classmethod
+    def _normalize_transport_mode(cls, value: Any) -> Literal["client", "server"]:
+        """规范化连接模式字段。"""
+        normalized_value = _normalize_string(value).lower()
+        return "server" if normalized_value == "server" else "client"
 
     @field_validator(
         "heartbeat_interval",

--- a/plugin.py
+++ b/plugin.py
@@ -1,7 +1,7 @@
 """内置 NapCat 适配器插件。
 
 当前实现承担完整的 QQ / NapCat 消息网关职责：
-1. 作为客户端连接 NapCat / OneBot v11 WebSocket 服务。
+1. 通过 WebSocket client/server 模式接入 NapCat / OneBot v11 服务。
 2. 将入站消息、通知事件与元事件转换为 Host 侧结构。
 3. 将 Host 出站消息转换为 OneBot 动作并发送。
 4. 通过公开 API 暴露 QQ 平台专属查询与管理动作。
@@ -75,7 +75,7 @@ class NapCatAdapterPlugin(
         route_type="duplex",
         platform="qq",
         protocol="napcat",
-        description="NapCat 正向 WebSocket 双工消息网关",
+        description="NapCat WebSocket 双工消息网关（支持 client/server）",
     )
     async def handle_napcat_gateway(
         self,

--- a/transport.py
+++ b/transport.py
@@ -13,13 +13,14 @@ if TYPE_CHECKING:
     from aiohttp import ClientWebSocketResponse as AiohttpClientWebSocketResponse
 
 try:
-    from aiohttp import ClientSession, ClientTimeout, WSMsgType
+    from aiohttp import ClientSession, ClientTimeout, WSMsgType, web
 
     AIOHTTP_AVAILABLE = True
 except ImportError:
     ClientSession = cast(Any, None)
     ClientTimeout = cast(Any, None)
     WSMsgType = cast(Any, None)
+    web = cast(Any, None)
     AIOHTTP_AVAILABLE = False
 
 if not TYPE_CHECKING:
@@ -27,7 +28,7 @@ if not TYPE_CHECKING:
 
 
 class NapCatTransportClient:
-    """NapCat 正向 WebSocket 客户端。"""
+    """NapCat WebSocket 传输客户端（支持 client/server 双模式）。"""
 
     def __init__(
         self,
@@ -50,6 +51,7 @@ class NapCatTransportClient:
         self._on_payload = on_payload
         self._server_config: Optional[NapCatServerConfig] = None
         self._connection_task: Optional[asyncio.Task[None]] = None
+        self._server_runner: Optional[Any] = None
         self._pending_actions: Dict[str, asyncio.Future[Dict[str, Any]]] = {}
         self._background_tasks: Set[asyncio.Task[Any]] = set()
         self._send_lock = asyncio.Lock()
@@ -77,7 +79,7 @@ class NapCatTransportClient:
         self._warned_missing_token_for_ws_url = None
 
     async def start(self) -> None:
-        """启动 NapCat 正向 WebSocket 连接循环。
+        """启动 NapCat WebSocket 连接循环。
 
         Raises:
             RuntimeError: 当缺少配置或依赖时抛出。
@@ -108,6 +110,12 @@ class NapCatTransportClient:
             connection_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await connection_task
+
+        server_runner = self._server_runner
+        self._server_runner = None
+        if server_runner is not None:
+            with contextlib.suppress(Exception):
+                await server_runner.cleanup()
 
         await self._cancel_background_tasks()
         await self._notify_connection_closed()
@@ -145,43 +153,134 @@ class NapCatTransportClient:
             self._pending_actions.pop(echo_id, None)
 
     async def _connection_loop(self) -> None:
-        """维护单个 WebSocket 连接，并在断开后按配置重连。"""
-        assert ClientSession is not None
-        assert ClientTimeout is not None
-
+        """根据配置选择 client/server 模式并维持连接。"""
         while not self._stop_requested:
             server_config = self._server_config
             if server_config is None:
                 return
 
-            ws_url = server_config.build_ws_url()
-            timeout = ClientTimeout(total=None, connect=10)
-            self._log_connection_attempt(ws_url, server_config)
-
             try:
-                async with ClientSession(headers=self._build_headers(server_config), timeout=timeout) as session:
-                    async with session.ws_connect(ws_url, heartbeat=server_config.heartbeat_interval or None) as ws:
-                        self._ws = ws
-                        self._logger.info(f"NapCat 适配器已连接: {ws_url}")
-                        disconnect_reason = await self._receive_loop(ws)
-                        self._log_connection_closed(ws_url, server_config, disconnect_reason)
+                if server_config.is_server_mode():
+                    await self._server_loop(server_config)
+                else:
+                    await self._client_loop(server_config)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 self._logger.warning(
-                    f"NapCat 适配器连接失败: {exc}"
+                    f"NapCat 适配器连接循环异常: {exc}"
                     f"{self._build_missing_token_hint(server_config)}"
                     f"{self._build_reconnect_hint(server_config)}"
                 )
-            finally:
+
+            if self._stop_requested:
+                return
+
+            await asyncio.sleep(server_config.reconnect_delay_sec)
+
+    async def _client_loop(self, server_config: NapCatServerConfig) -> None:
+        """维护 client 模式连接，并在断开后按配置重连。"""
+        assert ClientSession is not None
+        assert ClientTimeout is not None
+
+        ws_url = server_config.build_ws_url()
+        timeout = ClientTimeout(total=None, connect=10)
+        self._log_connection_attempt(ws_url, server_config)
+
+        try:
+            async with ClientSession(headers=self._build_headers(server_config), timeout=timeout) as session:
+                async with session.ws_connect(ws_url, heartbeat=server_config.heartbeat_interval or None) as ws:
+                    self._ws = ws
+                    self._logger.info(f"NapCat 适配器已连接: {ws_url}")
+                    disconnect_reason = await self._receive_loop(ws)
+                    self._log_connection_closed(ws_url, server_config, disconnect_reason)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._logger.warning(
+                f"NapCat 适配器连接失败: {exc}"
+                f"{self._build_missing_token_hint(server_config)}"
+                f"{self._build_reconnect_hint(server_config)}"
+            )
+        finally:
+            self._ws = None
+            await self._notify_connection_closed()
+            self._fail_pending_actions("NapCat connection interrupted")
+
+    async def _server_loop(self, server_config: NapCatServerConfig) -> None:
+        """维护 server 模式监听，等待 NapCat 主动连接。"""
+        assert web is not None
+
+        bind_host = server_config.host
+        bind_port = server_config.port
+        bind_label = f"ws://{bind_host}:{bind_port}{server_config.ws_path}"
+        self._logger.info(f"NapCat 适配器已进入 server 模式，开始监听: {bind_label}")
+
+        app = web.Application()
+        app.router.add_get(server_config.ws_path, self._handle_ws_upgrade)
+
+        runner = web.AppRunner(app)
+        self._server_runner = runner
+        await runner.setup()
+
+        site = web.TCPSite(runner, host=bind_host, port=bind_port)
+        await site.start()
+
+        try:
+            while not self._stop_requested:
+                await asyncio.sleep(0.5)
+        finally:
+            if self._server_runner is runner:
+                self._server_runner = None
+            with contextlib.suppress(Exception):
+                await runner.cleanup()
+
+    async def _handle_ws_upgrade(self, request: Any) -> Any:
+        """处理 server 模式下的 WebSocket 升级请求。"""
+        assert web is not None
+
+        server_config = self._server_config
+        if server_config is None:
+            return web.Response(status=503, text="NapCat adapter is not configured")
+
+        if not self._check_server_authorization(request, server_config):
+            return web.Response(status=401, text="Unauthorized")
+
+        ws = web.WebSocketResponse(heartbeat=server_config.heartbeat_interval or None)
+        await ws.prepare(request)
+
+        previous_ws = self._ws
+        if previous_ws is not None and not previous_ws.closed:
+            with contextlib.suppress(Exception):
+                await previous_ws.close(code=1000, message=b"Replaced by new NapCat connection")
+
+        self._ws = ws
+        peer = str(request.remote or "unknown")
+        self._logger.info(f"NapCat 适配器收到连接: {peer}")
+
+        try:
+            disconnect_reason = await self._receive_loop(ws)
+            self._logger.warning(f"NapCat 适配器连接已断开: {peer}，{disconnect_reason}{self._build_reconnect_hint(server_config)}")
+        finally:
+            if self._ws is ws:
                 self._ws = None
                 await self._notify_connection_closed()
                 self._fail_pending_actions("NapCat connection interrupted")
 
-            if self._stop_requested:
-                break
+        return ws
 
-            await asyncio.sleep(server_config.reconnect_delay_sec)
+    def _check_server_authorization(self, request: Any, server_config: NapCatServerConfig) -> bool:
+        """校验 server 模式下接入连接的鉴权信息。"""
+        token = server_config.token
+        if not token:
+            return True
+
+        auth_header = str(request.headers.get("Authorization") or "").strip()
+        if auth_header.startswith("Bearer "):
+            provided_token = auth_header[7:].strip()
+            return provided_token == token
+
+        return False
 
     async def _receive_loop(self, ws: AiohttpClientWebSocketResponse) -> str:
         """持续消费 WebSocket 消息并分发处理。
@@ -345,7 +444,9 @@ class NapCatTransportClient:
             server_config: 当前生效的 NapCat 服务端配置。
         """
         auth_mode = "已配置 token" if server_config.token else "未配置 token"
-        self._logger.debug(f"NapCat 适配器开始连接: {ws_url}（鉴权: {auth_mode}）")
+        self._logger.debug(
+            f"NapCat 适配器开始连接: {ws_url}（模式: {server_config.transport_mode}，鉴权: {auth_mode}）"
+        )
 
         if not server_config.token and self._warned_missing_token_for_ws_url != ws_url:
             self._logger.warning(


### PR DESCRIPTION
## 问题
当前适配器仅能作为 Websocket 客户端连接到 NapCat 的 Websocket 服务器，当在wsl虚拟机中部署了麦麦，而NapCat在Windows物理机上运行，由于Windows防火墙限制，适配器无法连接到Windows上的Websocket服务器。反之，当Windows作为 Websocket 客户端连接wsl虚拟机中的 Websocket 服务器时却相当轻松。

## 改动
重构NapCat传输层，拆分client/server连接逻辑，新增配置项支持两种运行模式：
1. 新增transport_mode配置项，支持client主动连接和server被动监听，默认为client，即现有模式。
2. 实现server模式下的WebSocket服务监听和连接处理。
3. 新增ws_path配置项用于配置WebSocket访问路径。
4. 完善配置校验和日志输出，适配双模式运行

## 配置说明
1. transport_mode默认为client，即现有模式。
2. ws_path配置项用于配置WebSocket访问路径，默认为“/”，和原有行为一致。可配置自定义路径，如配置“/ws”时，作为client将连接`ws://localhost:3001/ws`，作为server时将监听此地址。
3. token在client 模式下用于请求头 Authorization: Bearer <token>；server 模式下用于校验 NapCat 连接请求头中的 Bearer token。

## 验证
已在本机进行验证，插件可正常加载，server模式下能够正常收发消息。